### PR TITLE
do jlabbrev autocompletion before default one

### DIFF
--- a/jlabbrev.lua
+++ b/jlabbrev.lua
@@ -2537,10 +2537,10 @@ function abbrevCompleter(buf)
 	return completions, suggestions
 end
 
-function preInsertTab(bp)
+function preAutocomplete(bp)
 	local buf = bp.Buf
 
-	if not buf.Settings["jlabbrev.enable"] then
+	if bp.Cursor:HasSelection() or buf.HasSuggestions or not buf.Settings["jlabbrev.enable"] then
 		return true
 	end
 
@@ -2552,6 +2552,12 @@ function preInsertTab(bp)
 		buf:Replace(match[1], match[2], substitution)
 		return false
 	else
-		return not buf:Autocomplete(abbrevCompleter)
+		completions, suggestions = abbrevCompleter(buf)
+		if #suggestions > 0 then
+			buf.Completions, buf.Suggestions = completions, suggestions
+			buf.HasSuggestions = true
+			buf.CurSuggestion = -1
+		end
+		return true
 	end
 end


### PR DESCRIPTION
This fixes #5. It works (as far as I can tell), but it is kind of a hack. I don't see an easier way, however.